### PR TITLE
Remove restart policy from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,18 +2,15 @@ version: "3"
 services:
   db:
     image: postgres
-    restart: always
     environment:
       POSTGRES_USER: songbook
       POSTGRES_DB: songbook
       POSTGRES_PASSWORD: password
     ports:
       - 5432:5432
-    # command: -d 5
 
   adminer:
     image: adminer
-    restart: always
     ports:
       - 8080:8080
 


### PR DESCRIPTION
Previously, some (but not all) services in the docker-compose had their
restart policy set to always which meant that they would be running at
times when one might not expect them to (such as after a computer
restart).

These have now been deleted, equivalent to setting them to 'no'.